### PR TITLE
Deixando o código mais idiomático

### DIFF
--- a/floatconv.go
+++ b/floatconv.go
@@ -1,29 +1,35 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 )
 
+var ErrInvalidNumber = errors.New("the value is not a number")
+
 func main() {
-	checkNumber(getValue())
-}
-
-func getValue() string {
-	if len(os.Args)-1 < 1 {
-		fmt.Println("One arg is requerid for this program")
-		os.Exit(1)
+	if len(os.Args) < 2 {
+		log.Fatal("One arg is required for this program")
 	}
-	value := os.Args[1]
-	return value
-}
 
-func checkNumber(value string) {
-	fValue, err := strconv.ParseFloat(value, 64)
+	msg, err := checkNumber(os.Args[1])
+
 	if err != nil {
-		fmt.Printf("The value <%s> is not a number\n", value)
-		os.Exit(1)
+		log.Fatal(err)
 	}
-	fmt.Printf("The value <%f> is a valid number\n", fValue)
+
+	fmt.Print(msg)
+}
+
+func checkNumber(value string) (string, error) {
+	fValue, err := strconv.ParseFloat(value, 64)
+
+	if err != nil {
+		return "", ErrInvalidNumber
+	}
+
+	return fmt.Sprintf("The value <%f> is a valid number", fValue), nil
 }

--- a/floatconv_test.go
+++ b/floatconv_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestCheckNumber(t *testing.T) {
+	tt := []struct {
+		description string
+		value       string
+		message     string
+		e           error
+	}{
+		{description: "empty value", value: "", message: "", e: ErrInvalidNumber},
+		{description: "random string", value: "foo", message: "", e: ErrInvalidNumber},
+		{description: "boolean", value: "false", message: "", e: ErrInvalidNumber},
+		{description: "integer", value: "1", message: "The value <1.000000> is a valid number", e: nil},
+		{description: "float", value: "50.5", message: "The value <50.500000> is a valid number", e: nil},
+	}
+
+	for _, test := range tt {
+		t.Run(test.description, func(t *testing.T) {
+			msg, err := checkNumber(test.value)
+
+			if err != test.e {
+				t.Fatalf("expected error %v; got %v", test.e, err)
+			}
+
+			if msg != test.message {
+				t.Fatalf("expected message %v; got %v", test.message, msg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Primeiro parabéns pelos estudos. Li o seu [post no Medium](https://medium.com/@denis_santos/tutorial-conversor-num%C3%A9rico-em-golang-3a5680ef9bc) e resolvi fazer umas sugestões no código.

Aqui vou listar algumas delas, mas fique a vontade para pergunta/discutir outros pontos:

## Código
- removi a função `getValue` e passei ela para a `main`;
- usei `log.Fatalf` ao invés de `fmt` com `os.Exit(1)` ( no fundo o objetivo é o mesmo );
- `checkNumber` agora retorna 2 valores, pois desacopla o que fazer com o valor do corpo da função e fica mais fácil de testar ( vide `floatconv_test` )

## Testes

- table test para listar todos os casos possíveis e seus respectivos retornos;
- `t.Run` para dar uma descrição maior a cada caso de teste;
- `t.Fatalf` pois a suite de testes vai parar assim que um teste falhar;

## Alternativa

Sei que a ideia do código foi a título de estudo e acho sensacional. Uma outra versão da mesma ideia pode ser feita com o pacote [flag](https://golang.org/pkg/flag/) que já faz o parse e a validação do tipo de dado para você ( nesse caso se o valor é `float` ).

Abaixo vai um exemplo de como seria uma versão do código atual usando esse pacote:

``` go
package main

import (
	"flag"
	"fmt"
)

var fValue float64

func init() {
	flag.Float64Var(&fValue, "f", 0, "some float value")
}

func main() {
	flag.Parse()
	fmt.Printf("The value <%f> is a valid number\n", fValue)
}
```

E para usar só rodar com a flag `-f` ( ex: `go run FILE.go -f 10` )

Parabéns mais uma vez, pelo post e pela iniciativa dos estudos.
Abraço!